### PR TITLE
feat: Add batch XML access statistics import service

### DIFF
--- a/access-stats/archive/access-stats-2025-12-15.xml
+++ b/access-stats/archive/access-stats-2025-12-15.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<accessStatistics date="2025-12-15" source="external-analytics-system">
+    <entries>
+        <entry>
+            <documentId>1</documentId>
+            <accessCount>42</accessCount>
+        </entry>
+        
+        <entry>
+            <documentId>2</documentId>
+            <accessCount>17</accessCount>
+        </entry>
+        
+        <entry>
+            <documentId>3</documentId>
+            <accessCount>156</accessCount>
+        </entry>
+    </entries>
+</accessStatistics>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -91,6 +91,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.5</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/at/technikum_wien/swen3/paperless/config/AccessStatisticsConfig.java
+++ b/backend/src/main/java/at/technikum_wien/swen3/paperless/config/AccessStatisticsConfig.java
@@ -1,0 +1,19 @@
+package at.technikum_wien.swen3.paperless.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "access-stats")
+public class AccessStatisticsConfig {
+
+    private String inputDir = "/access-stats";
+
+    private String archiveDir = "/access-stats/archive";
+
+    private String filePattern = "access-stats-.*\\.xml";
+
+    private String cronSchedule = "0 0 1 * * ?";
+}

--- a/backend/src/main/java/at/technikum_wien/swen3/paperless/dto/AccessEntryXml.java
+++ b/backend/src/main/java/at/technikum_wien/swen3/paperless/dto/AccessEntryXml.java
@@ -1,0 +1,21 @@
+package at.technikum_wien.swen3.paperless.dto;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AccessEntryXml {
+
+    @XmlElement(name = "documentId")
+    private Long documentId;
+
+    @XmlElement(name = "accessCount")
+    private Long accessCount;
+}

--- a/backend/src/main/java/at/technikum_wien/swen3/paperless/dto/AccessStatisticsXml.java
+++ b/backend/src/main/java/at/technikum_wien/swen3/paperless/dto/AccessStatisticsXml.java
@@ -1,0 +1,26 @@
+package at.technikum_wien.swen3.paperless.dto;
+
+import jakarta.xml.bind.annotation.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@XmlRootElement(name = "accessStatistics")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AccessStatisticsXml {
+
+    @XmlAttribute(name = "date")
+    private String date;
+
+    @XmlAttribute(name = "source")
+    private String source;
+
+    @XmlElementWrapper(name = "entries")
+    @XmlElement(name = "entry")
+    private List<AccessEntryXml> entries;
+}

--- a/backend/src/main/java/at/technikum_wien/swen3/paperless/dto/DocumentDto.java
+++ b/backend/src/main/java/at/technikum_wien/swen3/paperless/dto/DocumentDto.java
@@ -19,5 +19,6 @@ public class DocumentDto {
     private String status;
     private String summary;
     private long fileSize;
+    private long accessCount;
     private List<TagDto> tags;
 }

--- a/backend/src/main/java/at/technikum_wien/swen3/paperless/entity/Document.java
+++ b/backend/src/main/java/at/technikum_wien/swen3/paperless/entity/Document.java
@@ -43,12 +43,12 @@ public class Document {
     @Column
     private long fileSize;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private long accessCount = 0;
+
     @Builder.Default
     @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(
-            name = "document_tags",
-            joinColumns = @JoinColumn(name = "document_id"),
-            inverseJoinColumns = @JoinColumn(name = "tag_id")
-    )
+    @JoinTable(name = "document_tags", joinColumns = @JoinColumn(name = "document_id"), inverseJoinColumns = @JoinColumn(name = "tag_id"))
     private Set<Tag> tags = new HashSet<>();
 }

--- a/backend/src/main/java/at/technikum_wien/swen3/paperless/service/AccessStatisticsImporterService.java
+++ b/backend/src/main/java/at/technikum_wien/swen3/paperless/service/AccessStatisticsImporterService.java
@@ -1,0 +1,135 @@
+package at.technikum_wien.swen3.paperless.service;
+
+import at.technikum_wien.swen3.paperless.config.AccessStatisticsConfig;
+import at.technikum_wien.swen3.paperless.dto.AccessEntryXml;
+import at.technikum_wien.swen3.paperless.dto.AccessStatisticsXml;
+import at.technikum_wien.swen3.paperless.entity.Document;
+import at.technikum_wien.swen3.paperless.repository.DocumentRepository;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AccessStatisticsImporterService {
+
+    private final DocumentRepository documentRepository;
+    private final AccessStatisticsConfig config;
+
+    @Scheduled(cron = "${access-stats.cron-schedule:0 0 1 * * ?}")
+    public void importAccessStatistics() {
+        log.info("Starting access statistics import job");
+
+        File inputFolder = new File(config.getInputDir());
+        if (!inputFolder.exists() || !inputFolder.isDirectory()) {
+            log.warn("Access statistics input directory does not exist: {}", config.getInputDir());
+            return;
+        }
+
+        // Create archive folder if missing
+        new File(config.getArchiveDir()).mkdirs();
+
+        Pattern filePattern = Pattern.compile(config.getFilePattern());
+
+        try (Stream<Path> paths = Files.walk(Paths.get(config.getInputDir()), 1)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(path -> filePattern.matcher(path.getFileName().toString()).matches())
+                    .forEach(this::processXmlFile);
+        } catch (IOException e) {
+            log.error("Error reading access statistics input directory", e);
+        }
+
+        log.info("Access statistics import job completed");
+    }
+
+    @Transactional
+    public void processXmlFile(Path filePath) {
+        log.info("Processing access statistics file: {}", filePath.getFileName());
+
+        try {
+            // Parse the XML file
+            JAXBContext context = JAXBContext.newInstance(AccessStatisticsXml.class);
+            Unmarshaller unmarshaller = context.createUnmarshaller();
+            AccessStatisticsXml stats = (AccessStatisticsXml) unmarshaller.unmarshal(filePath.toFile());
+
+            if (stats.getEntries() == null || stats.getEntries().isEmpty()) {
+                log.warn("No entries found in file: {}", filePath.getFileName());
+            } else {
+                log.info("Found {} entries in file from date: {}, source: {}",
+                        stats.getEntries().size(), stats.getDate(), stats.getSource());
+
+                int successCount = 0;
+                int skipCount = 0;
+
+                for (AccessEntryXml entry : stats.getEntries()) {
+                    if (updateDocumentAccessCount(entry)) {
+                        successCount++;
+                    } else {
+                        skipCount++;
+                    }
+                }
+
+                log.info("Processed file {}: {} entries updated, {} entries skipped (document not found)",
+                        filePath.getFileName(), successCount, skipCount);
+            }
+
+            // Move file to archive
+            archiveFile(filePath);
+
+        } catch (JAXBException e) {
+            log.error("Failed to parse XML file: {}", filePath, e);
+        } catch (Exception e) {
+            log.error("Failed to process access statistics file: {}", filePath, e);
+        }
+    }
+
+    private boolean updateDocumentAccessCount(AccessEntryXml entry) {
+        if (entry.getDocumentId() == null || entry.getAccessCount() == null) {
+            log.warn("Invalid entry: missing documentId or accessCount");
+            return false;
+        }
+
+        Optional<Document> documentOpt = documentRepository.findById(entry.getDocumentId());
+
+        if (documentOpt.isEmpty()) {
+            log.warn("Document not found with ID: {}", entry.getDocumentId());
+            return false;
+        }
+
+        Document document = documentOpt.get();
+        long newCount = document.getAccessCount() + entry.getAccessCount();
+        document.setAccessCount(newCount);
+        documentRepository.save(document);
+
+        log.debug("Updated document {} access count: {} -> {}",
+                entry.getDocumentId(), document.getAccessCount() - entry.getAccessCount(), newCount);
+
+        return true;
+    }
+
+    private void archiveFile(Path filePath) {
+        try {
+            Path destPath = Paths.get(config.getArchiveDir(), filePath.getFileName().toString());
+            Files.move(filePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+            log.info("Archived file {} to {}", filePath.getFileName(), config.getArchiveDir());
+        } catch (IOException e) {
+            log.error("Failed to archive file: {}", filePath, e);
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -23,3 +23,10 @@ spring.servlet.multipart.max-request-size=5MB
 # ES
 spring.elasticsearch.uris=${ELASTIC_URL:http://localhost:9200}
 spring.data.elasticsearch.repositories.enabled=true
+
+# Access Statistics Batch Import
+access-stats.input-dir=${ACCESS_STATS_INPUT_DIR:/access-stats}
+access-stats.archive-dir=${ACCESS_STATS_ARCHIVE_DIR:/access-stats/archive}
+access-stats.file-pattern=${ACCESS_STATS_FILE_PATTERN:access-stats-.*\\.xml}
+# TESTING: Run every minute (change back to "0 0 1 * * ?" daily at 1:00 AM)
+access-stats.cron-schedule=${ACCESS_STATS_CRON:0 * * * * ?}

--- a/backend/src/test/java/at/technikum_wien/swen3/paperless/service/AccessStatisticsImporterServiceTest.java
+++ b/backend/src/test/java/at/technikum_wien/swen3/paperless/service/AccessStatisticsImporterServiceTest.java
@@ -1,0 +1,188 @@
+package at.technikum_wien.swen3.paperless.service;
+
+import at.technikum_wien.swen3.paperless.config.AccessStatisticsConfig;
+import at.technikum_wien.swen3.paperless.entity.Document;
+import at.technikum_wien.swen3.paperless.repository.DocumentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccessStatisticsImporterServiceTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @Mock
+    private AccessStatisticsConfig config;
+
+    @InjectMocks
+    private AccessStatisticsImporterService importerService;
+
+    @TempDir
+    Path tempDir;
+
+    private Path inputDir;
+    private Path archiveDir;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        inputDir = tempDir.resolve("input");
+        archiveDir = tempDir.resolve("archive");
+        Files.createDirectories(inputDir);
+        Files.createDirectories(archiveDir);
+
+        lenient().when(config.getInputDir()).thenReturn(inputDir.toString());
+        lenient().when(config.getArchiveDir()).thenReturn(archiveDir.toString());
+        lenient().when(config.getFilePattern()).thenReturn("access-stats-.*\\.xml");
+    }
+
+    @Test
+    void importAccessStatistics_whenValidXml_thenUpdatesDocumentAndArchivesFile() throws IOException {
+        // Arrange
+        String xmlContent = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <accessStatistics date="2025-12-15" source="test-system">
+                    <entries>
+                        <entry>
+                            <documentId>1</documentId>
+                            <accessCount>42</accessCount>
+                        </entry>
+                    </entries>
+                </accessStatistics>
+                """;
+
+        Path xmlFile = inputDir.resolve("access-stats-2025-12-15.xml");
+        Files.writeString(xmlFile, xmlContent);
+
+        Document document = Document.builder()
+                .id(1L)
+                .title("Test Document")
+                .accessCount(10)
+                .build();
+
+        when(documentRepository.findById(1L)).thenReturn(Optional.of(document));
+        when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // Act
+        importerService.importAccessStatistics();
+
+        // Assert
+        verify(documentRepository).findById(1L);
+        verify(documentRepository).save(any(Document.class));
+        assertThat(document.getAccessCount()).isEqualTo(52); // 10 + 42
+
+        // Verify file was archived
+        assertThat(Files.exists(xmlFile)).isFalse();
+        assertThat(Files.exists(archiveDir.resolve("access-stats-2025-12-15.xml"))).isTrue();
+    }
+
+    @Test
+    void importAccessStatistics_whenDocumentNotFound_thenSkipsEntryAndArchives() throws IOException {
+        // Arrange
+        String xmlContent = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <accessStatistics date="2025-12-15" source="test-system">
+                    <entries>
+                        <entry>
+                            <documentId>999</documentId>
+                            <accessCount>100</accessCount>
+                        </entry>
+                    </entries>
+                </accessStatistics>
+                """;
+
+        Path xmlFile = inputDir.resolve("access-stats-2025-12-15.xml");
+        Files.writeString(xmlFile, xmlContent);
+
+        when(documentRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // Act
+        importerService.importAccessStatistics();
+
+        // Assert
+        verify(documentRepository).findById(999L);
+        verify(documentRepository, never()).save(any());
+
+        // File should still be archived
+        assertThat(Files.exists(archiveDir.resolve("access-stats-2025-12-15.xml"))).isTrue();
+    }
+
+    @Test
+    void importAccessStatistics_whenNoMatchingFiles_thenDoesNothing() throws IOException {
+        // Arrange - create a file that doesn't match the pattern
+        Path nonMatchingFile = inputDir.resolve("other-file.txt");
+        Files.writeString(nonMatchingFile, "not an xml file");
+
+        // Act
+        importerService.importAccessStatistics();
+
+        // Assert
+        verifyNoInteractions(documentRepository);
+        // Non-matching file should still exist
+        assertThat(Files.exists(nonMatchingFile)).isTrue();
+    }
+
+    @Test
+    void importAccessStatistics_whenInputDirDoesNotExist_thenReturnsEarly() {
+        // Arrange
+        when(config.getInputDir()).thenReturn("/nonexistent/path");
+
+        // Act
+        importerService.importAccessStatistics();
+
+        // Assert
+        verifyNoInteractions(documentRepository);
+    }
+
+    @Test
+    void importAccessStatistics_whenMultipleEntries_thenUpdatesAll() throws IOException {
+        // Arrange
+        String xmlContent = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <accessStatistics date="2025-12-15" source="test-system">
+                    <entries>
+                        <entry>
+                            <documentId>1</documentId>
+                            <accessCount>10</accessCount>
+                        </entry>
+                        <entry>
+                            <documentId>2</documentId>
+                            <accessCount>20</accessCount>
+                        </entry>
+                    </entries>
+                </accessStatistics>
+                """;
+
+        Path xmlFile = inputDir.resolve("access-stats-2025-12-15.xml");
+        Files.writeString(xmlFile, xmlContent);
+
+        Document doc1 = Document.builder().id(1L).title("Doc 1").accessCount(0).build();
+        Document doc2 = Document.builder().id(2L).title("Doc 2").accessCount(5).build();
+
+        when(documentRepository.findById(1L)).thenReturn(Optional.of(doc1));
+        when(documentRepository.findById(2L)).thenReturn(Optional.of(doc2));
+        when(documentRepository.save(any(Document.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        // Act
+        importerService.importAccessStatistics();
+
+        // Assert
+        assertThat(doc1.getAccessCount()).isEqualTo(10);
+        assertThat(doc2.getAccessCount()).isEqualTo(25); // 5 + 20
+        verify(documentRepository, times(2)).save(any(Document.class));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,8 @@ services:
     image: minio/minio:latest
     container_name: paperless_minio
     ports:
-      - "9000:9000" # API Port
-      - "9090:9090" # Console Port
+      - "9000:9000"
+      - "9090:9090"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -103,6 +103,7 @@ services:
       ELASTIC_URL: http://elasticsearch:9200
     volumes:
       - ./import:/import
+      - ./access-stats:/access-stats
 
   paperless-ui:
     build: ./frontend


### PR DESCRIPTION
- Add AccessStatisticsImporterService with configurable cron schedule
- Add JAXB DTOs (AccessStatisticsXml, AccessEntryXml) for XML parsing
- Add AccessStatisticsConfig for externalized configuration
- Extend Document entity with accessCount field
- Add unit tests for AccessStatisticsImporterService
- Add sample XML file in access-stats/
- Add volume mount for access-stats in docker-compose.yml